### PR TITLE
Fix crawl metadata and sitemap

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,7 +5,7 @@ import Script from 'next/script'
 import NavBar from '@/components/NavBar/navbar-wrapper'
 import Footer from '@/components/Footer'
 
-import { sharedOpenGraphMetadata } from '@/lib/shared-metadata'
+import { sharedOpenGraphMetadata, siteUrl } from '@/lib/shared-metadata'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -14,12 +14,15 @@ const description =
   "Fun-filled athletics in Sydney's Northern Beaches and Woolgoolga on the Mid-North Coast"
 
 export const metadata = {
-  metadataBase: new URL('https://star-athletics.com.au/'),
+  metadataBase: new URL(siteUrl),
   title: {
     template: `%s | ${title}`,
     default: title,
   },
   description,
+  alternates: {
+    canonical: '/',
+  },
   openGraph: {
     title,
     description,

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,6 +1,28 @@
+import { reader } from '@/app/keystatic/reader'
+import { extractTextFromDocument, sharedOpenGraphMetadata } from '@/lib/shared-metadata'
+
 import Hero from './_partials/Hero'
 import Introduction from './_partials/Introduction'
 import Testimonials from './_partials/Testimonials'
+
+export async function generateMetadata() {
+  const pageData = await reader.singletons.homepage.readOrThrow({
+    resolveLinkedFiles: true,
+  })
+
+  const metaTitleAndDescription = {
+    title: 'Star Athletics',
+    description: extractTextFromDocument(pageData.introductionText, 160),
+  }
+
+  return {
+    ...metaTitleAndDescription,
+    openGraph: {
+      ...metaTitleAndDescription,
+      ...sharedOpenGraphMetadata,
+    },
+  }
+}
 
 export default function Home() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import { MetadataRoute } from 'next'
+
+import { siteUrl } from '@/lib/shared-metadata'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/keystatic/'],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,38 +1,41 @@
 import { MetadataRoute } from 'next'
 
 import { reader } from './keystatic/reader'
+import { siteUrl } from '@/lib/shared-metadata'
+
+function url(path = '') {
+  return `${siteUrl}${path}`
+}
+
+function sitemapEntry(path = ''): MetadataRoute.Sitemap[number] {
+  return {
+    url: url(path),
+    lastModified: new Date(),
+  }
+}
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const coaches = await reader.collections.coaches.list()
-  const coachesUrls = coaches.map((coach) => ({
-    url: `https://www.star-athletics.com.au/coaches/${coach}`,
-    lastModified: new Date(),
-  }))
+  const [coaches, generalPages, sydneyPages, woopiPages] = await Promise.all([
+    reader.collections.coaches.list(),
+    reader.collections.generalPages.list(),
+    reader.collections.sydneyPages.list(),
+    reader.collections.woopiPages.list(),
+  ])
 
   return [
-    // Homepage
-    { url: 'https://www.star-athletics.com.au', lastModified: new Date() },
-    // Contact
-    { url: 'https://www.star-athletics.com.au/contact', lastModified: new Date() },
-    // Register
-    { url: 'https://www.star-athletics.com.au/register', lastModified: new Date() },
-    // FAQ
-    { url: 'https://www.star-athletics.com.au/faq', lastModified: new Date() },
-
-    // Coaches
-    { url: 'https://www.star-athletics.com.au/coaches', lastModified: new Date() },
-    ...coachesUrls,
-    // Sydney pages
-    { url: 'https://www.star-athletics.com.au/sydney', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/sydney/sessions', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/sydney/one-on-one', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/sydney/holiday-camps', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/sydney/popup-clinics', lastModified: new Date() },
-    // Woopi pages
-    { url: 'https://www.star-athletics.com.au/woopi', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/woopi/sessions', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/woopi/one-on-one', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/woopi/holiday-camps', lastModified: new Date() },
-    { url: 'https://www.star-athletics.com.au/woopi/popup-clinics', lastModified: new Date() },
+    sitemapEntry(),
+    sitemapEntry('/contact'),
+    sitemapEntry('/register'),
+    sitemapEntry('/faq'),
+    sitemapEntry('/coaches'),
+    sitemapEntry('/partnerships'),
+    sitemapEntry('/sydney'),
+    sitemapEntry('/sydney/sessions'),
+    sitemapEntry('/woopi'),
+    sitemapEntry('/woopi/sessions'),
+    ...coaches.map((coach) => sitemapEntry(`/coaches/${coach}`)),
+    ...generalPages.map((slug) => sitemapEntry(`/${slug}`)),
+    ...sydneyPages.map((slug) => sitemapEntry(`/sydney/${slug}`)),
+    ...woopiPages.map((slug) => sitemapEntry(`/woopi/${slug}`)),
   ]
 }

--- a/src/lib/shared-metadata.ts
+++ b/src/lib/shared-metadata.ts
@@ -1,11 +1,12 @@
 import { Metadata } from 'next'
 import { decode } from 'he'
 
+export const siteUrl = 'https://www.star-athletics.com.au'
 const seoImagePath = '/images/seo-image.png'
 
 export const sharedOpenGraphMetadata: Metadata['openGraph'] = {
   locale: 'en_AU',
-  url: 'https://star-athletics.com.au',
+  url: siteUrl,
   images: [{ url: seoImagePath, width: 1200, height: 630, alt: 'Star Athletics' }],
 }
 


### PR DESCRIPTION
## Summary
- add a Next robots route that allows crawling and advertises the sitemap
- centralize the canonical site URL on https://www.star-athletics.com.au
- expand sitemap generation to include Keystatic dynamic pages
- add homepage metadata from the homepage content

## Validation
- git diff --cached --check passed before commit
- production diagnosis showed /robots.txt returning 500 before this fix
- local production build could not be completed because the existing dependency/tooling state fails during lint/type checks after compilation